### PR TITLE
fix arguments and remove namespace

### DIFF
--- a/apriltags2_ros/launch/continuous_detection.launch
+++ b/apriltags2_ros/launch/continuous_detection.launch
@@ -6,11 +6,11 @@
     <arg name="image_topic" default="image_raw"/>
 
     <!-- Set parameters -->
-    <rosparam command="load" file="$(find apriltags2_ros)/config/settings.yaml" ns="$(arg node_namespace)"/>
-    <rosparam command="load" file="$(find apriltags2_ros)/config/tags.yaml" ns="$(arg node_namespace)"/>
+    <rosparam command="load" file="$(find apriltags2_ros)/config/settings.yaml"/>
+    <rosparam command="load" file="$(find apriltags2_ros)/config/tags.yaml"/>
 
     <!-- Translates 2D into 3D using SolvePnP -->
-    <node pkg="apriltags2_ros" type="continuous_detector_node" ns="$(arg node_namespace)" name="continuous_detector_node"
+    <node pkg="apriltags2_ros" type="continuous_detector_node" name="continuous_detector_node"
           clear_params="false" output="screen" launch-prefix="$(arg launch_prefix)">
         <!-- Remap topics from those used in code to those on the ROS network -->
         <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)"/>

--- a/apriltags2_ros/launch/continuous_pose_detection.launch
+++ b/apriltags2_ros/launch/continuous_pose_detection.launch
@@ -6,19 +6,24 @@
     <arg name="image_topic" default="image_raw"/>
 
     <!-- Set parameters -->
-    <rosparam command="load" file="$(find apriltags2_ros)/config/settings.yaml" ns="$(arg node_namespace)"/>
-    <rosparam command="load" file="$(find apriltags2_ros)/config/tags.yaml" ns="$(arg node_namespace)"/>
+    <rosparam command="load" file="$(find apriltags2_ros)/config/settings.yaml"/>
+    <rosparam command="load" file="$(find apriltags2_ros)/config/tags.yaml"/>
 
     <param name="apriltags2_ros/publish_tag_detections_image" type="bool" value="true"/>
     <param name="apriltags2_ros/camera_frame" type="str" value="$(arg camera_frame)"/>
 
     <!-- 3D Pose Topic -->
     <node pkg="apriltags2_ros" type="continuous_pose_detector_node" name="continuous_pose_detector_node"
-          clear_params="false" output="screen" launch-prefix="$(arg launch_prefix)" ns="$(arg node_namespace)">
+          clear_params="false" output="screen" launch-prefix="$(arg launch_prefix)">
         <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)"/>
         <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
     </node>
 
-    <include file="$(find apriltags2_ros)/launch/continuous_detection.launch" />
+    <include file="$(find apriltags2_ros)/launch/continuous_detection.launch">
+        <arg name="node_namespace" value="$(arg node_namespace)"/>
+        <arg name="camera_name" value="$(arg camera_name)"/>
+        <arg name="camera_frame" value="$(arg camera_frame)"/>
+        <arg name="image_topic" value="$(arg image_topic)"/>
+    </include>
 
 </launch>


### PR DESCRIPTION
I passed the camera/image information to the continuous node and removed the namepsace.

Reason for removing namespace was because it would attempt to subscribe to /namespace/camera/topic. If you try to remap the camera topic the simulation crashes.